### PR TITLE
feat: popover auto-placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ export default () => (
   - [numberOfLines (from Popover)](#numberOfLines)
   - [onAction](#onAction)
   - [position (from Popover)](#position)
+  - [strictPosition](#strictPosition)
   - [style](#style)
   - [visible (from Popover)](#visible)
 
@@ -128,6 +129,16 @@ Callback to monitor the popover visibility state. Called whenever `visible` chan
   content="See profile"
 >
   <Text>@morning_cafe</Text>
+</Popable>
+```
+
+#### strictPosition
+
+If the popover should be placed on the opposite side when it doesn't fit at the given position. If a popover is on the left of the screen and its position is left, the position will be turned to right by default. If `strictPosition` is `false`, the popover will remain on the left. **Defaults to `true`.**
+
+```jsx
+<Popable strictPosition={false} position="left">
+  @morning_cafe
 </Popable>
 ```
 

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -22,112 +22,123 @@ export type PopoverProps = {
   position?: 'top' | 'right' | 'bottom' | 'left';
 } & ViewProps;
 
-export default ({
-  animated = true,
-  animationType = 'timing',
-  backgroundColor,
-  caret: withCaret = true,
-  caretPosition = 'center',
-  children,
-  numberOfLines,
-  visible = true,
-  position = 'bottom',
-  style,
-  ...extraProps
-}: PopoverProps) => {
-  const isContentString = typeof children === 'string';
-  const isHorizontalLayout = position === 'left' || position === 'right';
-  const prevVisible = useRef(visible);
-  const opacity = useRef(new Animated.Value(visible ? 1 : 0)).current;
+export default React.forwardRef<View, PopoverProps>(
+  (
+    {
+      animated = true,
+      animationType = 'timing',
+      backgroundColor,
+      caret: withCaret = true,
+      caretPosition = 'center',
+      children,
+      numberOfLines,
+      visible = true,
+      position = 'bottom',
+      style,
+      ...extraProps
+    },
+    ref
+  ) => {
+    const isContentString = typeof children === 'string';
+    const isHorizontalLayout = position === 'left' || position === 'right';
+    const prevVisible = useRef(visible);
+    const opacity = useRef(new Animated.Value(visible ? 1 : 0)).current;
 
-  useEffect(() => {
-    let animation: Animated.CompositeAnimation | undefined;
+    useEffect(
+      () => {
+        let animation: Animated.CompositeAnimation | undefined;
 
-    if (animated) {
-      if (visible && !prevVisible.current) {
-        animation = Animated[animationType](opacity, {
-          toValue: 1,
-          duration: 250,
-          useNativeDriver: true,
-        });
-      } else if (!visible && prevVisible.current) {
-        animation = Animated[animationType](opacity, {
-          toValue: 0,
-          duration: 250,
-          useNativeDriver: true,
-        });
-      }
+        if (animated) {
+          if (visible && !prevVisible.current) {
+            animation = Animated[animationType](opacity, {
+              toValue: 1,
+              duration: 250,
+              useNativeDriver: true,
+            });
+          } else if (!visible && prevVisible.current) {
+            animation = Animated[animationType](opacity, {
+              toValue: 0,
+              duration: 250,
+              useNativeDriver: true,
+            });
+          }
 
-      animation?.start();
+          animation?.start();
+        }
+
+        prevVisible.current = visible;
+
+        return () => animation?.stop();
+      },
+      [visible] // eslint-disable-line react-hooks/exhaustive-deps
+    );
+
+    const caret = (
+      <Caret
+        align={caretPosition}
+        position={position}
+        backgroundColor={backgroundColor}
+        style={{ zIndex: 0 }}
+      />
+    );
+
+    let animationTranslation: any;
+
+    if (isHorizontalLayout) {
+      animationTranslation = {
+        translateX: opacity.interpolate({
+          inputRange: [0, 1],
+          outputRange: position === 'left' ? [5, 0] : [-5, 0],
+        }),
+      };
+    } else {
+      animationTranslation = {
+        translateY: opacity.interpolate({
+          inputRange: [0, 1],
+          outputRange: position === 'top' ? [5, 0] : [-5, 0],
+        }),
+      };
     }
 
-    prevVisible.current = visible;
-
-    return () => animation?.stop();
-  }, [visible, animated, animationType, opacity]);
-
-  const caret = (
-    <Caret
-      align={caretPosition}
-      position={position}
-      backgroundColor={backgroundColor}
-      style={{ zIndex: 0 }}
-    />
-  );
-
-  let animationTranslation: any;
-
-  if (isHorizontalLayout) {
-    animationTranslation = {
-      translateX: opacity.interpolate({
-        inputRange: [0, 1],
-        outputRange: position === 'left' ? [5, 0] : [-5, 0],
-      }),
-    };
-  } else {
-    animationTranslation = {
-      translateY: opacity.interpolate({
-        inputRange: [0, 1],
-        outputRange: position === 'top' ? [5, 0] : [-5, 0],
-      }),
-    };
-  }
-
-  return (
-    <View
-      style={[styles.container, style]}
-      pointerEvents={visible ? 'auto' : 'none'}
-      {...extraProps}
-    >
-      <Animated.View
-        style={[
-          { opacity, transform: [animationTranslation] },
-          isHorizontalLayout && styles.containerHorizontal,
-        ]}
+    return (
+      <View
+        ref={ref}
+        style={[styles.container, style]}
+        pointerEvents={visible ? 'auto' : 'none'}
+        {...extraProps}
       >
-        {withCaret && (position === 'bottom' || position === 'right') && caret}
-
-        <View
+        <Animated.View
           style={[
-            styles.content,
-            isContentString && styles.contentTextOnly,
-            !!backgroundColor && { backgroundColor },
+            { opacity, transform: [animationTranslation] },
+            isHorizontalLayout && styles.containerHorizontal,
           ]}
         >
-          {isContentString ? (
-            <Text numberOfLines={numberOfLines} style={styles.contentText}>
-              {children}
-            </Text>
-          ) : (
-            children
-          )}
-        </View>
+          {withCaret &&
+            (position === 'bottom' || position === 'right') &&
+            caret}
 
-        {withCaret && (position === 'top' || position === 'left') && caret}
-      </Animated.View>
-    </View>
-  );
-};
+          <View
+            style={[
+              styles.content,
+              isContentString && styles.contentTextOnly,
+              !!backgroundColor && { backgroundColor },
+            ]}
+          >
+            {isContentString ? (
+              <Text numberOfLines={numberOfLines} style={styles.contentText}>
+                {children}
+              </Text>
+            ) : (
+              children
+            )}
+          </View>
+
+          {withCaret && (position === 'top' || position === 'left') && caret}
+        </Animated.View>
+      </View>
+    );
+  }
+);
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
Fix #2.

- Add `strictPosition` to `Popable`: if `position` is set to left and there is not enough space to show the popover, it will be placed on the right. Same goes for top/bottom.