### PR TITLE
feat: make custom popover content interactive on native

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Style the `Popover` component using any [`View` style property](https://reactnat
 Style the wrapping `View` component using any [`View` style property](https://reactnative.dev/docs/view-style-props).
 
 ```jsx
-<Popable wrapperStyle={{ flex: 1, display: "flex" }}>@morning_cafe</Popable>
+<Popable wrapperStyle={{ flex: 1, display: 'flex' }}>@morning_cafe</Popable>
 ```
 
 ### Popover
@@ -179,6 +179,7 @@ export default () => <Popover>@morning_cafe</Popover>;
   - [backgroundColor](#backgroundColor)
   - [caret](#caret)
   - [caretPosition](#caretPosition)
+  - [forceInitialAnimation](#forceInitialAnimation)
   - [numberOfLines](#numberOfLines)
   - [visible](#visible)
   - [position](#position)
@@ -236,6 +237,14 @@ Position for the caret: `left`, `center` or `right`. **Defaults to `center`.**
 
 ```jsx
 <Popover caretPosition="right">@morning_cafe</Popover>
+```
+
+#### forceInitialAnimation
+
+If the popover should animate when it renders for the first time. This means that if `visible` is set to `true`, the popover will fade in after it mounted. Likewise, if `visible` is `false`, the popover will fade out. If this property is kept falsy, the popover will be displayed in its initial visibility state, without animating. It is very unlikely you would ever need this property. **Defaults to `false`.**
+
+```jsx
+<Popover forceInitialAnimation>@morning_cafe</Popover>
 ```
 
 #### numberOfLines

--- a/src/Backdrop/Backdrop.d.ts
+++ b/src/Backdrop/Backdrop.d.ts
@@ -1,10 +1,10 @@
-import type { RefObject } from 'react';
+import type { ReactNode, RefObject } from 'react';
 import type { View } from 'react-native';
 
 export type BackdropProps = {
-  enabled: boolean;
-  visible: boolean;
+  children?: ReactNode;
+  childrenRef: RefObject<View>;
   onPress: () => void;
   popoverRef: RefObject<View>;
-  childrenRef: RefObject<View>;
+  visible: boolean;
 };

--- a/src/Backdrop/Backdrop.tsx
+++ b/src/Backdrop/Backdrop.tsx
@@ -1,25 +1,43 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Modal,
   //@ts-ignore
   Pressable,
   StyleSheet,
 } from 'react-native';
+import { ANIMATION_DURATION } from '../constants';
 import type { BackdropProps } from './Backdrop.d';
 
-export default function Backdrop({ enabled, onPress, visible }: BackdropProps) {
-  if (!enabled) {
-    return null;
-  }
+export default function Backdrop({
+  children,
+  onPress,
+  visible,
+}: BackdropProps) {
+  const [delayedVisible, setDelayedVisible] = useState(visible);
+
+  useEffect(() => {
+    // When `Modal.visible` changes, the inner view gets hidden
+    // immediately. This gives no time to `Popover` to animate
+    // when `visible` becomes `false`. By delaying the `visible`
+    // property, it gives extra time for the popover to animate,
+    // then hide the modal
+    if (visible) {
+      setDelayedVisible(true);
+    } else {
+      setTimeout(() => setDelayedVisible(false), ANIMATION_DURATION);
+    }
+  }, [visible]);
 
   return (
     <Modal
-      visible={visible}
+      visible={delayedVisible}
       onRequestClose={onPress}
       hardwareAccelerated
       transparent
     >
-      <Pressable onPress={onPress} style={styles.pressable} />
+      <Pressable onPress={onPress} style={styles.pressable}>
+        {children}
+      </Pressable>
     </Modal>
   );
 }

--- a/src/Backdrop/Backdrop.web.tsx
+++ b/src/Backdrop/Backdrop.web.tsx
@@ -3,16 +3,11 @@ import type { BackdropProps } from './Backdrop.d';
 
 export default function Backdrop({
   childrenRef,
-  enabled,
   onPress,
   popoverRef,
   visible,
 }: BackdropProps) {
   useEffect(() => {
-    if (!enabled) {
-      return;
-    }
-
     const handler = (event: any) => {
       if (
         // @ts-ignore
@@ -30,7 +25,7 @@ export default function Backdrop({
 
     // @ts-ignore
     return () => document.removeEventListener('mousedown', handler);
-  }, [enabled, visible, onPress, popoverRef, childrenRef]);
+  }, [visible, onPress, popoverRef, childrenRef]);
 
   return null;
 }

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { Animated, StyleSheet, Text, View, ViewProps } from 'react-native';
 import Caret from './Caret';
+import { ANIMATION_DURATION } from './constants';
 import {
   POPOVER_BACKGROUND_COLOR,
   BORDER_RADIUS,
@@ -17,6 +18,7 @@ export type PopoverProps = {
   caret?: boolean;
   caretPosition?: 'left' | 'center' | 'right';
   children: string | React.ReactElement;
+  forceInitialAnimation?: boolean;
   numberOfLines?: number;
   visible?: boolean;
   position?: 'top' | 'right' | 'bottom' | 'left';
@@ -30,6 +32,7 @@ const Popover = React.forwardRef<View, PopoverProps>(function Popover(
     caret: withCaret = true,
     caretPosition = 'center',
     children,
+    forceInitialAnimation = false,
     numberOfLines,
     visible = true,
     position = 'bottom',
@@ -41,23 +44,27 @@ const Popover = React.forwardRef<View, PopoverProps>(function Popover(
   const isContentString = typeof children === 'string';
   const isHorizontalLayout = position === 'left' || position === 'right';
   const prevVisible = useRef(visible);
-  const opacity = useRef(new Animated.Value(visible ? 1 : 0)).current;
+  const opacity = useRef(
+    new Animated.Value(
+      visible ? (forceInitialAnimation ? 0 : 1) : forceInitialAnimation ? 1 : 0
+    )
+  ).current;
 
   useEffect(
     () => {
       let animation: Animated.CompositeAnimation | undefined;
 
       if (animated) {
-        if (visible && !prevVisible.current) {
+        if (visible && (!prevVisible.current || forceInitialAnimation)) {
           animation = Animated[animationType](opacity, {
             toValue: 1,
-            duration: 250,
+            duration: ANIMATION_DURATION,
             useNativeDriver: true,
           });
-        } else if (!visible && prevVisible.current) {
+        } else if (!visible && (prevVisible.current || forceInitialAnimation)) {
           animation = Animated[animationType](opacity, {
             toValue: 0,
-            duration: 250,
+            duration: ANIMATION_DURATION,
             useNativeDriver: true,
           });
         }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const ANIMATION_DURATION = 250;


### PR DESCRIPTION
Related to #7.

`Backdrop` now renders a copy of the original popover inside the modal on native.

This keeps popover inner elements interactive using a custom view:

```jsx
// onPress wouldn't have been fired before these changes because a top modal/pressable
// was blocking all the touch events underneath.
// Now it does, because a copy of the original popover is rendered on top of everything
<Popover content={<Menu><Menu.Item onPress={...}>Contact</Menu.Item>}>
  <Icon name="menu" />
</Popover>
```