### PR TITLE
fix: props.onAction not fired when popable dismissed

### DIFF
--- a/src/Popable.tsx
+++ b/src/Popable.tsx
@@ -123,7 +123,8 @@ const Popable = forwardRef<PopableManager, PopableProps>(function Popable(
 
   const handleHidePopover = useCallback(() => {
     setPopoverVisible(false);
-  }, []);
+    onAction?.(false);
+  }, [onAction]);
 
   const handlePopoverLayout = useCallback(() => {
     popoverRef.current?.measureInWindow((x, y, width, height) => {


### PR DESCRIPTION
Fix #15.

`props.onAction` was not called when `Popable` was dismissed.

This was due to `props.onAction` not being called inside the `handleHidePopover` callback.