### PR TITLE
Introduce custom styles for several parts of the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,30 @@ Style the `Popover` component using any [`View` style property](https://reactnat
 <Popable style={{ opacity: 0.8 }}>@morning_cafe</Popable>
 ```
 
+#### contentStyle
+
+Style the content component inside the `Popover` component using any [`View` style property](https://reactnative.dev/docs/view-style-props).
+
+```jsx
+<Popable contentStyle={{ padding: 10 }}>@morning_cafe</Popable>
+```
+
+#### contentTextStyle
+
+Style the text inside the `Popover` component using any [`Text` style property](https://reactnative.dev/docs/text-style-props).
+
+```jsx
+<Popable contentTextStyle={{ color: 'black' }}>@morning_cafe</Popable>
+```
+
+#### caretStyle
+
+Style the caret component inside the `Popover` component using any [`View` style property](https://reactnative.dev/docs/view-style-props).
+
+```jsx
+<Popable caretStyle={{ height: 10 }}>@morning_cafe</Popable>
+```
+
 #### wrapperStyle
 
 Style the wrapping `View` component using any [`View` style property](https://reactnative.dev/docs/view-style-props).

--- a/src/Popable.tsx
+++ b/src/Popable.tsx
@@ -26,12 +26,15 @@ export type PopableProps = {
   backgroundColor?: PopoverProps['backgroundColor'];
   caret?: PopoverProps['caret'];
   caretPosition?: PopoverProps['caretPosition'];
+  caretStyle?: PopoverProps['caretStyle'];
   children: any;
   content: PopoverProps['children'];
   numberOfLines?: PopoverProps['numberOfLines'];
   onAction?: (visible: boolean) => void;
   position?: PopoverProps['position'];
   strictPosition?: boolean;
+  contentStyle?: PopoverProps['contentStyle'];
+  contentTextStyle?: PopoverProps['contentTextStyle'];
   style?: PopoverProps['style'];
   visible?: boolean;
   wrapperStyle?: ViewProps['style'];
@@ -53,7 +56,10 @@ const Popable = forwardRef<PopableManager, PopableProps>(function Popable(
     children,
     caret,
     caretPosition,
+    caretStyle,
     content,
+    contentStyle,
+    contentTextStyle,
     numberOfLines,
     onAction,
     position = 'top',
@@ -197,7 +203,10 @@ const Popable = forwardRef<PopableManager, PopableProps>(function Popable(
     backgroundColor,
     caret,
     caretPosition,
+    caretStyle,
     children: content,
+    contentStyle,
+    contentTextStyle,
     numberOfLines,
     position: computedPosition,
   };

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -1,5 +1,12 @@
 import React, { useEffect, useRef } from 'react';
-import { Animated, StyleSheet, Text, View, ViewProps } from 'react-native';
+import {
+  Animated,
+  StyleSheet,
+  Text,
+  TextProps,
+  View,
+  ViewProps,
+} from 'react-native';
 import Caret from './Caret';
 import { ANIMATION_DURATION } from './constants';
 import {
@@ -17,6 +24,9 @@ export type PopoverProps = {
   backgroundColor?: string;
   caret?: boolean;
   caretPosition?: 'left' | 'center' | 'right';
+  caretStyle?: ViewProps['style'];
+  contentStyle?: ViewProps['style'];
+  contentTextStyle?: TextProps['style'];
   children: string | React.ReactElement;
   forceInitialAnimation?: boolean;
   numberOfLines?: number;
@@ -31,7 +41,10 @@ const Popover = React.forwardRef<View, PopoverProps>(function Popover(
     backgroundColor,
     caret: withCaret = true,
     caretPosition = 'center',
+    caretStyle,
     children,
+    contentStyle,
+    contentTextStyle,
     forceInitialAnimation = false,
     numberOfLines,
     visible = true,
@@ -84,7 +97,7 @@ const Popover = React.forwardRef<View, PopoverProps>(function Popover(
       align={caretPosition}
       position={position}
       backgroundColor={backgroundColor}
-      style={styles.caret}
+      style={[styles.caret, caretStyle]}
     />
   );
 
@@ -126,10 +139,14 @@ const Popover = React.forwardRef<View, PopoverProps>(function Popover(
             styles.content,
             isContentString && styles.contentTextOnly,
             !!backgroundColor && { backgroundColor },
+            contentStyle,
           ]}
         >
           {isContentString ? (
-            <Text numberOfLines={numberOfLines} style={styles.contentText}>
+            <Text
+              numberOfLines={numberOfLines}
+              style={[styles.contentText, contentTextStyle]}
+            >
               {children}
             </Text>
           ) : (


### PR DESCRIPTION
This pull request introduces 3 new custom style props in order to get the customisation that you need for these 3 elements:

- Caret: Triangle shown above the popup
- Content Container: Element wrapping the content 
- Content Text: When passed as a text the content

for each of these elements of the library this PR introduces a style prop:

#### contentStyle

Style the content component inside the `Popover` component using any [`View` style property](https://reactnative.dev/docs/view-style-props).

```jsx
<Popable contentStyle={{ padding: 10 }}>@morning_cafe</Popable>
```

#### contentTextStyle

Style the text inside the `Popover` component using any [`Text` style property](https://reactnative.dev/docs/text-style-props).

```jsx
<Popable contentTextStyle={{ color: 'black' }}>@morning_cafe</Popable>
```

#### caretStyle

Style the caret component inside the `Popover` component using any [`View` style property](https://reactnative.dev/docs/view-style-props).

```jsx
<Popable caretStyle={{ height: 10 }}>@morning_cafe</Popable>
```

These props have been tested in the example app and work, one of the things that allows me to do is to have a shadow around the popup for Android like this:

```
<Popable
      backgroundColor={'#FFFFFF'}
      caretStyle={{elevation: 5}}
      content="Test"
      contentStyle={{elevation: 5}}
      contentTextStyle={{ color: 'black' }}>
        {children}
    </Popable>
```
 
 This way is easier to change the look and feel of your popup as you can see on the screenshot
 
 
![Screenshot_1626791098](https://user-images.githubusercontent.com/6560136/126341191-191471d4-8198-4ae1-b32f-7c7807aeaf0f.png)
